### PR TITLE
Output logs to stdout instead of stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	errs := log.New(os.Stderr, "", 0)
-	logs := errs
+	logs := log.New(os.Stdout, "", 0)
 	if *silent {
 		logs = log.New(ioutil.Discard, "", 0)
 	}


### PR DESCRIPTION
Previously logs were sent to the same writer as errors which was
using os.Stderr, or the user had the option to discard all logs.

This change continues to send errors to os.Stderr, but uses os.Stdout
for logs. Users can still discard logs using -silent flag, or redirect
output themselves.

This allows me to run the application via cron with `ghbackup [opts] >> /var/log/ghbackup` and have cron email me any errors but I can still keep the logs.