### PR TITLE
Exponential back off & Mask secrets from log

### DIFF
--- a/ghbackup/backup.go
+++ b/ghbackup/backup.go
@@ -50,7 +50,7 @@ func maskSecrets(values, secrets []string) []string {
 	out := make([]string, len(values))
 	for _, secret := range secrets {
 		for vIndex, value := range values {
-			out[vIndex] = strings.ReplaceAll(value, secret, "###")
+			out[vIndex] = strings.Replace(value, secret, "###", -1)
 		}
 	}
 	return out

--- a/ghbackup/backup.go
+++ b/ghbackup/backup.go
@@ -16,6 +16,7 @@ const (
 	stateNew = iota
 	stateChanged
 	stateUnchanged
+	stateFailed
 )
 
 // Clone new repo or pull in existing repo.
@@ -25,7 +26,7 @@ func (c Config) backup(r repo) (repoState, error) {
 
 	repoExists, err := exists(repoDir)
 	if err != nil {
-		return stateUnchanged, fmt.Errorf("cannot check if repo exists: %v", err)
+		return stateFailed, fmt.Errorf("cannot check if repo exists: %v", err)
 	}
 
 	var cmd *exec.Cmd
@@ -40,7 +41,7 @@ func (c Config) backup(r repo) (repoState, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return stateUnchanged, fmt.Errorf("error running command %v (%v): %v (%v)", cmd.Args, cmd.Path, string(out), err)
+		return stateFailed, fmt.Errorf("error running command %v (%v): %v (%v)", cmd.Args, cmd.Path, string(out), err)
 	}
 
 	return gitState(repoExists, string(out)), nil

--- a/ghbackup/backup.go
+++ b/ghbackup/backup.go
@@ -53,8 +53,11 @@ func (c Config) backup(r repo) (repoState, error) {
 // maskSecrets hides sensitive data
 func maskSecrets(values, secrets []string) []string {
 	out := make([]string, len(values))
+	for vIndex, value := range values {
+		out[vIndex] = value
+	}
 	for _, secret := range secrets {
-		for vIndex, value := range values {
+		for vIndex, value := range out {
 			out[vIndex] = strings.Replace(value, secret, "###", -1)
 		}
 	}

--- a/ghbackup/backup.go
+++ b/ghbackup/backup.go
@@ -40,6 +40,11 @@ func (c Config) backup(r repo) (repoState, error) {
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if !repoExists {
+			// clean up clone dir after a failed clone
+			// if it was a clean clone only
+			_ = os.RemoveAll(repoDir)
+		}
 		return stateFailed, fmt.Errorf("error running command %v (%v): %v (%v)", maskSecrets(cmd.Args, []string{c.Secret}), cmd.Path, string(out), err)
 	}
 	return gitState(repoExists, string(out)), nil

--- a/ghbackup/backup_test.go
+++ b/ghbackup/backup_test.go
@@ -1,0 +1,42 @@
+package ghbackup
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_maskSecrets(t *testing.T) {
+	type args struct {
+		values  []string
+		secrets []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "identicall",
+			args: args{
+				values:  []string{"ok", "haha secrethaha", "sdjdsajsasecretsdsasecret,tmp"},
+				secrets: []string{"ok", "haha secrethaha", "sdjdsajsasecretsdsasecret,tmp"},
+			},
+			want: []string{"###", "###", "###"},
+		},
+		{
+			name: "generic",
+			args: args{
+				values:  []string{"ok", "haha secrethaha", "sdjdsajsasecretsdsasecret,tmp"},
+				secrets: []string{"secret"},
+			},
+			want: []string{"ok", "haha ###haha", "sdjdsajsa###sdsa###,tmp"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maskSecrets(tt.args.values, tt.args.secrets); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("maskSecrets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ghbackup/run.go
+++ b/ghbackup/run.go
@@ -12,7 +12,7 @@ import (
 
 func newExponentialBackOff() *backoff.ExponentialBackOff {
 	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = 10 * time.Second
+	b.InitialInterval = 1 * time.Second
 	b.MaxElapsedTime = 5 * time.Minute
 	return b
 }

--- a/ghbackup/run.go
+++ b/ghbackup/run.go
@@ -37,7 +37,7 @@ func Run(config Config) error {
 
 	results := make(chan repoState)
 
-	// Backup repositories in parallel with exponential-backoff retries
+	// Backup repositories in parallel with retries
 	go each(repos, config.Workers, func(r repo) {
 		state, err := config.backup(r)
 		for _, sleepDuration := range []time.Duration{5, 15, 45, 90, 180, -1} {

--- a/ghbackup/run.go
+++ b/ghbackup/run.go
@@ -60,7 +60,6 @@ func Run(config Config) error {
 				state, err = config.backup(r)
 				continue
 			}
-			config.Log.Printf("repository %v managed to get cloned successfully", r)
 			break
 		}
 		results <- state

--- a/ghbackup/run.go
+++ b/ghbackup/run.go
@@ -12,6 +12,8 @@ import (
 
 func newExponentialBackOff() *backoff.ExponentialBackOff {
 	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 10 * time.Second
+	b.MaxElapsedTime = 5 * time.Minute
 	return b
 }
 

--- a/ghbackup/run.go
+++ b/ghbackup/run.go
@@ -50,15 +50,17 @@ func Run(config Config) error {
 		state, err := config.backup(r)
 		for {
 			if err != nil {
-				config.Err.Println(err)
 				sleepDuration := eBackoff.NextBackOff()
 				if sleepDuration == backoff.Stop {
+					config.Log.Printf("repository %v failed to get cloned: %v", r, err)
 					break
 				}
+				config.Err.Println(err)
 				time.Sleep(sleepDuration)
 				state, err = config.backup(r)
 				continue
 			}
+			config.Log.Printf("repository %v managed to get cloned successfully", r)
 			break
 		}
 		results <- state


### PR DESCRIPTION
- Check if there are clone errors
- Add `newExponentialBackOff` for clone operations (we have observed frequent DNS/network issues with GitHub - easy to recover from with a retry)
- Mask the GitHub token from the log